### PR TITLE
Replaced IERC20Upgradeable (removed by Openzeppelin) with IERC20

### DIFF
--- a/AxynomStaking.sol
+++ b/AxynomStaking.sol
@@ -1,26 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "./libraries/StakeLogic.sol";
 import "./libraries/StakingUtils.sol";
 import "./libraries/PoolInteractions.sol";
 
 contract AxynomStaking is Initializable, AccessControlUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeable {
-    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using SafeERC20 for IERC20;
     using StakeLogic for StakeLogic.StakeInfo;
     using StakingUtils for uint256;
 
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
 
-    IERC20Upgradeable public axynomToken;
+    IERC20 public axynomToken;
     address public rewardsPool;
     address public treasury;
 
@@ -72,7 +72,7 @@ contract AxynomStaking is Initializable, AccessControlUpgradeable, ReentrancyGua
         __ReentrancyGuard_init();
         __UUPSUpgradeable_init();
 
-        axynomToken = IERC20Upgradeable(_token);
+        axynomToken = IERC20(_token);
         rewardsPool = _rewardsPool;
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
@@ -206,7 +206,7 @@ contract AxynomStaking is Initializable, AccessControlUpgradeable, ReentrancyGua
 
     function setToken(address newToken) external onlyRole(MANAGER_ROLE) {
         require(newToken != address(0), "Invalid token");
-        axynomToken = IERC20Upgradeable(newToken);
+        axynomToken = IERC20(newToken);
     }
 
     function pause() external onlyRole(MANAGER_ROLE) {

--- a/AxynomTreasury.sol
+++ b/AxynomTreasury.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.25;
 
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
@@ -17,7 +17,7 @@ contract AxynomTreasury is
     PausableUpgradeable,
     UUPSUpgradeable
 {
-    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using SafeERC20 for IERC20;
 
     // ───────────────────────────────────────────────
     // 🔐 Roles
@@ -82,7 +82,7 @@ contract AxynomTreasury is
 
         require(authorized, "Not authorized");
 
-        IERC20Upgradeable(token).safeTransfer(to, amount);
+        IERC20(token).safeTransfer(to, amount);
         emit TreasuryTransfer(token, to, amount);
     }
 
@@ -103,7 +103,7 @@ contract AxynomTreasury is
     }
 
     function deposit(address token, uint256 amount) external {
-        IERC20Upgradeable(token).safeTransferFrom(msg.sender, address(this), amount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
         emit TreasuryReceived(msg.sender, amount);
     }
 
@@ -140,7 +140,7 @@ contract AxynomTreasury is
         require(token != address(0), "Invalid token");
         require(rewardsPool != address(0), "Rewards pool not set");
 
-        IERC20Upgradeable(token).safeTransfer(rewardsPool, amount);
+        IERC20(token).safeTransfer(rewardsPool, amount);
         emit RewardsPoolRefilled(token, amount, rewardsPool);
     }
 
@@ -170,7 +170,7 @@ contract AxynomTreasury is
         monthlySpent[currentMonth] += amount;
         require(monthlySpent[currentMonth] <= monthlyWalletCap, "Over monthly cap");
 
-        IERC20Upgradeable(token).safeTransfer(investmentWallet, amount);
+        IERC20(token).safeTransfer(investmentWallet, amount);
         emit WalletAllocation(token, investmentWallet, amount, reason);
     }
 
@@ -191,8 +191,8 @@ contract AxynomTreasury is
 
     function recoverStuckERC20(address token, address to) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(to != address(0), "Invalid recipient");
-        uint256 balance = IERC20Upgradeable(token).balanceOf(address(this));
-        IERC20Upgradeable(token).safeTransfer(to, balance);
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        IERC20(token).safeTransfer(to, balance);
     }
 
     // ───────────────────────────────────────────────

--- a/PoG.sol
+++ b/PoG.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol"
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-import "../libraries/PoGLogic.sol";
+import "./libraries/PoGLogic.sol";
 
 interface IContributionRegistry {
     function unclaimedPoints(address user) external view returns (uint256);

--- a/RewardsPool.sol
+++ b/RewardsPool.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.25;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title RewardsPool
  * @notice Modular token vault to hold and release rewards for staking/PoG.
  */
 contract RewardsPool is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
-    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using SafeERC20 for IERC20;
 
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
 
@@ -40,19 +40,19 @@ contract RewardsPool is Initializable, AccessControlUpgradeable, UUPSUpgradeable
 
     /// @notice View balance of any token held by this contract
     function getBalance(address token) external view returns (uint256) {
-        return IERC20Upgradeable(token).balanceOf(address(this));
+        return IERC20(token).balanceOf(address(this));
     }
 
     /// @notice Accept ERC20 tokens from Treasury
     function receiveFromTreasury(address token, uint256 amount) external {
         require(authorizedContracts[msg.sender], "Not authorized");
-        IERC20Upgradeable(token).safeTransferFrom(msg.sender, address(this), amount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
     }
 
     /// @notice Emergency withdrawal by manager
     function withdrawTo(address token, address to, uint256 amount) external onlyRole(MANAGER_ROLE) {
         require(to != address(0), "Invalid address");
-        IERC20Upgradeable(token).safeTransfer(to, amount);
+        IERC20(token).safeTransfer(to, amount);
         emit Refunded(token, amount, to);
     }
 
@@ -60,7 +60,7 @@ contract RewardsPool is Initializable, AccessControlUpgradeable, UUPSUpgradeable
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
     function approveConsumer(address token, address spender) external onlyRole(MANAGER_ROLE) {
-    IERC20Upgradeable(token).approve(spender, type(uint256).max);
+    IERC20(token).approve(spender, type(uint256).max);
 }
 
 /// @notice Called by PoG or Staking contracts to send rewards to contributors
@@ -68,7 +68,7 @@ function distributeReward(address token, address to, uint256 amount) external {
     require(authorizedContracts[msg.sender], "Not authorized");
     require(to != address(0), "Invalid recipient");
 
-    IERC20Upgradeable(token).safeTransfer(to, amount);
+    IERC20(token).safeTransfer(to, amount);
 }
 
 

--- a/libraries/PoolInteractions.sol
+++ b/libraries/PoolInteractions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 library PoolInteractions {
     function sendReward(
@@ -10,12 +10,12 @@ library PoolInteractions {
         uint256 amount
     ) internal {
         require(to != address(0), "Invalid recipient");
-        IERC20Upgradeable(tokenAddress).transfer(to, amount);
+        IERC20(tokenAddress).transfer(to, amount);
     }
 
     // Placeholder for future multi-token support
     function sendStablecoinReward(address stableToken, address to, uint256 amount) internal {
         require(to != address(0), "Invalid recipient");
-        IERC20Upgradeable(stableToken).transfer(to, amount);
+        IERC20(stableToken).transfer(to, amount);
     }
 }

--- a/libraries/RewardRouter.sol
+++ b/libraries/RewardRouter.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 library RewardRouter {
-    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using SafeERC20 for IERC20;
 
     /// @notice Transfers reward tokens from reward pool to user
     function sendReward(
@@ -15,6 +15,6 @@ library RewardRouter {
         uint256 amount
     ) internal {
         require(token != address(0) && rewardsPool != address(0), "Invalid token or pool");
-        IERC20Upgradeable(token).safeTransferFrom(rewardsPool, user, amount);
+        IERC20(token).safeTransferFrom(rewardsPool, user, amount);
     }
 }


### PR DESCRIPTION
Openzeppelin v5.0 release note states that these interfaces and libraries have been removed from the upgradeable-contracts and vanilla IERC20 (openzeppelin/contracts) should be used in their stead. 

To make the contracts suitable for future integration with openzeppelin, I've removed the IERC20Upgradeable and SafeERC20Upgradeable instances from the contracts and updated them with the vanilla IERC20 and SafeERC20 instances.

For Openzeppelin v5.0 release notes forum answer, refer to the following: 
https://forum.openzeppelin.com/t/is-ierc20upgradeable-removed-from-contracts-upgradeable/38088